### PR TITLE
Cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,4 +55,6 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'json'
 
+gem 'aasm'
+
 ruby '2.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    aasm (4.11.1)
     actioncable (5.0.0.1)
       actionpack (= 5.0.0.1)
       nio4r (~> 1.2)
@@ -161,6 +162,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aasm
   byebug
   coffee-rails (~> 4.2)
   geocoder

--- a/app/controllers/concerns/messages_helper.rb
+++ b/app/controllers/concerns/messages_helper.rb
@@ -5,7 +5,7 @@ module MessagesHelper
   
   def handler(req, message)
     puts "Incoming request status : #{req.status} - #{message.body}"
-    if req.process(:nil, message) #feeds the message into status state machine of Request
+    if req.process!(:nil, message) #feeds the message into status state machine of Request
       case req.status
           when :pending_responder
             return handle_help_request(req, message)
@@ -21,7 +21,7 @@ module MessagesHelper
 
   # status 3
   def handle_issue(req, message) #only gives more info for check in specific cases right now
-    if (req.issue == :check_in) #issue with checking in
+    if (req.check_in?) #issue with checking in
       info = find_poll_addr(req.address)
     end
     info = info || ""
@@ -54,7 +54,7 @@ module MessagesHelper
   # status 6
   def handle_responder(req,responder_id)
       if confirm_respondent(req, responder_id)
-        req.process(responder_id)
+        req.process!(responder_id)
         send_confirm_to_requester(req)
         return t(responder_offers_help)
       else
@@ -77,7 +77,7 @@ module MessagesHelper
   # helper status 6
   def confirm_respondent(req, responder_id)
    # check that respondent exist and request status is 6
-    if req.status != :pending_responder
+    if !req.pending_responder?
       return false
     end
     return !Responder.find(responder_id).nil?

--- a/app/controllers/concerns/messages_helper.rb
+++ b/app/controllers/concerns/messages_helper.rb
@@ -1,61 +1,31 @@
 module MessagesHelper
   require 'net/https'
   require 'uri'
-
-  require 'rubygems'
   require 'twilio-ruby'
-
+  
   def handler(req, message)
     puts "Incoming request status : #{req.status} - #{message.body}"
-    case req.status
-    when 1
-      req.update_attribute(:status, req.status + 1)
-      return "Welcome to VoterAid. Help is on the way! In order to assist you, we'll ask you a few questions. What's your address where you are registered to vote?\n Please respond with full street address, city and state."
-    when 2 # User responds with location
-      return record_address_ask_issue(req, message)
-    when 3 # User responds with issue number"
-      return record_issue_ask_need_responder(req, message)
-    when 4
-      if /n(o)?/i =~ message.body 
-        req.update_attribute(:status, 9)
-        return 'Congratulations! Your case has been resolved'
-      else
-        req.update_attribute(:status, req.status + 1)
-        return "Could you provide describe the problem you are experiencing?"
+    if req.process(:nil, message) #feeds the message into status state machine of Request
+      case req.status
+          when :pending_responder
+            return handle_help_request(req, message)
+          when :check_need_responder
+            return handle_issue(req, message)
+          else
+            return t(req.status), nil
       end
-    when 6
-      return "We are finding a responder to help you. This should only take a few minutes."
-    when 8 # already contact requestor for feedbacks
-      if  /y(es)?/i =~ message.body 
-        req.update_attribute(:status, 9)
-        return 'Congratulations! Your case has been resolved'
-      else
-        req.update_attribute(:status, 10)
-        return 'We are sorry that we are unavailable to solve the issue right now'
-      end
+    else
+      return t(:process_error) + t(req.status),nil
     end
-  end
-
-  # status 2
-  def record_address_ask_issue(req, message)
-    req.update_attributes({address: message.body, status: req.status + 1})
-    text = "What do you need help with?\n1.Problem with ID\n2.Name not on registration list\n3.Eligibility to vote was challenged\n4.Can't check in at the poll\n5.Problem with voting machine\n6.Line to vote is too long\n7.Problem with provisional ballot\n8.Other\nText the number of the problem you are experiencing"
-    return text
   end
 
   # status 3
-  def record_issue_ask_need_responder(req, message)
-    num = message.body.to_i
-    if (num>0 && num < 9)
-      if (num == 4) #voting line too long
-        info = find_poll_addr(req.address)
-      end
-      info = info || ""
-      req.update_attributes({issue: num, status: req.status+1})
-      return info + "Would you still like to be connected to a responder? Text Yes or No"
-    else
-      return "Sorry, we receive invalid input. Please reply with the number code of your issue."
+  def handle_issue(req, message) #only gives more info for check in specific cases right now
+    if (req.issue == :check_in) #issue with checking in
+      info = find_poll_addr(req.address)
     end
+    info = info || ""
+    return info + t(:check_need_responder), nil
   end
 
   # helper func in status 3
@@ -67,7 +37,6 @@ module MessagesHelper
     http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     request = Net::HTTP::Get.new(uri.request_uri)
     response = http.request(request)
-    response["header-here"] # All headers are lowercase
     res_hash = JSON.parse(response.body)
           address_hash = res_hash['pollingLocations'][0]['address']
           locationName = address_hash['locationName']
@@ -79,32 +48,17 @@ module MessagesHelper
 
   # status 5 
   def handle_help_request(req, message)
-      req.update_attribute(:desc, message.body)
-      finding = find_nearby_responders(req, message)
-      if finding.count(:all) > 0
-        req.update_attribute(:status, req.status+1)
-        return "Connecting to responders. We appreciate your patience" ,finding
-      else
-        req.update_attribute(:status, 10)
-        return "We are sorry, no body is available to assist right now", finding
-      end
+    return t(:pending_responder), Responder.near(req.address, 50).limit(5)
   end   
-
-  # helper status 5 
-  def find_nearby_responders(req, message)
-    # ToDo: Add logic to find responders
-    responders = Responder.near(req.address, 50).limit(5)
-    return responders
-  end
  
   # status 6
   def handle_responder(req,responder_id)
       if confirm_respondent(req, responder_id)
-        req.update_attributes({status: req.status + 1, responder_id: responder_id})
+        req.process(responder_id)
         send_confirm_to_requester(req)
-        return "Thank you for helping. Voter should contact you shortly."
-      else 
-        return "Thank you for offering your assistance. Someone else has already been assigned to this request."  
+        return t(responder_offers_help)
+      else
+        return t(:responder_already_assigned)
       end
   end
 
@@ -116,14 +70,14 @@ module MessagesHelper
     @client.account.messages.create(
       :from => from,
       :to => req.phone,
-      :body => "We've matched you with someone in your local precinct. Contact #{responder.fname} at #{responder.phone} "
+      :body => t(:responder_assigned, responder: responder.fname, phone: responder.phone)
     )
   end
 
   # helper status 6
   def confirm_respondent(req, responder_id)
    # check that respondent exist and request status is 6
-    if req.status != 6
+    if req.status != :pending_responder
       return false
     end
     return !Responder.find(responder_id).nil?

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,3 +1,5 @@
 class Message < ApplicationRecord
   belongs_to :request, inverse_of: :messages
+  validates :request_id, presence: true
+
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -18,7 +18,7 @@ class Request < ApplicationRecord
        }
   aasm column: :status, enum: true do
     state :new_request, initial: true
-    state :awaiting_address, :awaiting_issue, :check_need_responder, :await_description, :pending_responder, :responder_assigned, :pending_feedback, :resolved, :unresolved
+    state :awaiting_address, :awaiting_issue, :check_need_responder, :awaiting_desc, :pending_responder, :responder_assigned, :pending_feedback, :resolved, :unresolved
 
     event :process do
       transitions from: :new_request, to: :awaiting_address
@@ -37,7 +37,6 @@ class Request < ApplicationRecord
 
   def save_address(msg)
     self.address = msg.body
-    self.save
   end
 
   def save_issue(msg)
@@ -54,15 +53,15 @@ class Request < ApplicationRecord
     self.save
   end
 
-  def has_nearby_responders?
+  def has_nearby_responders?(*args)
     return Responder.near(self.address,50).count(:all) > 0
   end
 
   private
 
   def valid_issue?(msg)
-    digit = /\d/.match(msg.body).to_i
-    if digit > 0 and digit < issues.count
+    digit = /\d/.match(msg.body)[0].to_i
+    if digit > 0 and digit < Request.issues.count
       return digit
     else
       return false

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -1,5 +1,35 @@
 class Request < ApplicationRecord
+  include AASM #request as a state machine
   belongs_to :responder, inverse_of: :requests, optional: true
   has_many :messages, inverse_of: :request
+
+  enum issue: [:unknown, :id_problem, :not_on_registration_list, :eligibility_challenged, :check_in, :voting_machine, :line_too_long, :provisional_problem, :other]
+  enum status: {
+         new_request: 1,
+         awaiting_address: 2,
+         awaiting_issue: 3,
+         check_need_responder: 4,
+         awaiting_desc: 5,
+         pending_responder: 6,
+         responder_assigned: 7,
+         awaiting_feedback: 8,
+         resolved: 9,
+         unresolved: 10
+       }
+  aasm column: :status, enum: true do
+    state :new_request, initial: true
+    state :awaiting_address, :awaiting_issue, :check_need_responder, :await_description, :pending_responder, :responder_assigned, :pending_feedback, :resolved, :unresolved
+
+    event :process do
+      transition from: :new_request, to: :awaiting_address
+      transition from: :awaiting_address, to: :awaiting_issue
+      transition from: :check_need_responder, to: :awaiting_desc
+      transition from: :pending_responder, to: :responder_assigned
+      transition from: :responder_assigned, to: :awaiting_feedback
+    end
+
+
+  end
+
 
 end

--- a/app/models/responder.rb
+++ b/app/models/responder.rb
@@ -3,6 +3,11 @@ class Responder < ApplicationRecord
   geocoded_by :full_street_address   # can also be an IP address
   after_validation :geocode          # auto-fetch coordinates
 
+  validates :fname,:lname, presence: true
+  validates :phone, presence: true, format: { with: /\+1[0-9]{10}/ , message: "Please provide number in format +1XXXYYYZZZZ"}, uniqueness: true
+  validates :email, presence: true, format: { with: /@/ }
+  validates :address, :city, :state, :zip, presence: true
+
   def full_street_address
     return "#{address}, #{city}, #{state}"
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,10 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-easing/1.3/jquery.easing.min.js"></script>
 
 
-  <body>
-    <%= yield %>
-  </body>
+    <body>
+      <% flash.each do |name, msg| %>
+        <%= content_tag :div, msg, class: name %>
+      <% end %>
+      <%= yield %>
+    </body>
 </html>

--- a/app/views/responders/_form.html.erb
+++ b/app/views/responders/_form.html.erb
@@ -1,39 +1,50 @@
-  <%= form_for @responder do |f| %>
-  <%= f.label "First Name" %>
-  <%= f.text_field :fname, placeholder: "First Name", required: true %>
-  <br/>
+<%= form_for(@responder, class:"form-horizontal") do |f| %>
+  <div class="form-group">
+    <%= f.label "First Name", class: "col-xs-12 col-sm-3"%>
+    <%= f.text_field :fname, placeholder: "First Name", required: true, class:"col-xs-12 col-sm-7"%>
+  </div>
+  <div class="form-group">
+    <%= f.label "Last Name", class: "col-xs-12 col-sm-3"%>
+    <%= f.text_field :lname, placeholder: "Last Name", required: true, class:"col-xs-12 col-sm-7"%>
+  </div>
 
-  <%= f.label "Last Name" %>
-  <%= f.text_field :lname, placeholder: "Last Name", required: true %>
-  <br/>
+  <div class="form-group">
+    <%= f.label "Phone Number", class: "col-xs-12 col-sm-3" %>
+    <%= f.text_field :phone, placeholder: "Phone Number", required: true, class:"col-xs-12 col-sm-7"%>
+  </div>
 
-  <%= f.label "Phone Number" %>
-  <%= f.text_field :phone, placeholder: "Phone Number", required: true %>
-  <br/>
+  <div class="form-group">
+    <%= f.label "Email", class: "col-xs-12 col-sm-3" %>
+    <%= f.text_field :email, placeholder: "Email", required: true, class:"col-xs-12 col-sm-7" %>
+  </div>
 
-  <%= f.label "Email" %>
-  <%= f.text_field :email, placeholder: "Email", required: true %>
-  <br/>
+  <div class="form-group">
+    <%= f.label "Address", class: "col-xs-12 col-sm-3" %>
+    <%= f.text_field :address, placeholder: "123 Main St", required: true, class:"col-xs-12 col-sm-7" %>
+  </div>
 
-  <%= f.label "Address" %>
-  <%= f.text_field :address, placeholder: "123 Main St", required: true %>
-  <br />
+  <div class="form-group">
+    <%= f.label "City", class: "col-xs-12 col-sm-3" %>
+    <%= f.text_field :city, placholder: "City", required: true, class:"col-xs-12 col-sm-7" %>
+  </div>
 
-  <%= f.label "City" %>
-  <%= f.text_field :city, placholder: "City", required: true %>
+  <div class="form-group">
+    <%= f.label "State", class: "col-xs-12 col-sm-3" %>
+    <%= f.text_field :state, placeholder: "State", required: true, class:"col-xs-12 col-sm-7" %>
+  </div>
 
-  <%= f.label "State" %>
-  <%= f.text_field :state, placeholder: "State", required: true %>
-  <br/>
+  <div class="form-group">
+    <%= f.label "Zip Code", class: "col-xs-12 col-sm-3" %>
+    <%= f.text_field :zip, placeholder: "Zipcode", required: true, class:"col-xs-12 col-sm-7" %>
+  </div>
 
-  <%= f.label "Zip Code" %>
-  <%= f.text_field :zip, placeholder: "Zipcode", required: true %>
-  <br/>
+  <div class="form-group">
+    <%= f.label "Bar Number?", class: "col-xs-12 col-sm-3" %>
+    <%= f.text_field :barNum, placeholder: "Optional State Bar Number", required: false, class:"col-xs-12 col-sm-7" %>
+  </div>
+  </div>
 
-  <%= f.label "Bar Number?" %>
-  <%= f.text_field :barNum, placeholder: "Optional State Bar Number", required: false %>
-  <br/>
-
-
-  <%= f.submit "Submit", :class => 'btn btn-success' %>
-  <% end %>
+  <div class="row">
+    <%= f.submit "Submit", class: 'btn btn-success col-xs-12 col-sm-4 col-sm-offset-4' %>
+  </div>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,3 +21,30 @@
 
 en:
   hello: "Hello world"
+  awaiting_address: "Welcome to VoterAid. Help is on the way! In order to assist you, we'll ask you a few questions. What's your address where you are registered to vote?\n Please respond with full street address, city and state."
+  awaiting_issue: "What do you need help with?\n1.Problem with ID\n2.Name not on registration list\n3.Eligibility to vote was challenged\n4.Can't check in at the poll\n5.Problem with voting machine\n6.Line to vote is too long\n7.Problem with provisional ballot\n8.Other\nText the number of the problem you are experiencing"
+  check_need_responder: "Would you still like to be connected to a responder? Text Yes or No"
+  awaiting_desc: "Could you provide describe the problem you are experiencing?"
+  pending_responder:  "We are finding a responder to help you. This should only take a few minutes."
+  responder_assigned: "We've matched you with someone in your local precinct. Contact %{responder} at %{phone}"
+  awaiting_feedback: "Could you please provide us some feedback into the resolution of your case?"
+  resolved: 'Congratulations! Your case has been resolved'
+  unresolved: 'We are sorry that we are unavailable to solve the issue right now'
+  process_error: "Sorry, I didn't quite get that.\n"
+  nearby: "Hi, someone near %{address} needs your help. The voter is experiencing this issue: %{issue} \nThey have described the issue as: %{desc}. Please repond with Yes if you are able to help."
+  responder_offers_help: "Thank you for helping. Voter should contact you shortly."
+  responder_already_assigned: "Thank you for offering your assistance. Someone else has already been assigned to this request."
+
+  issues:
+    unknown: "Issue unknown"
+    id_problem: "Problem with ID"
+    not_on_registration_list: "Name not on registration list"
+    eligibility_challenged: "Eligibility to vote was challenged"
+    check_in: "Cannot check in at the poll"
+    voting_machine: "Problem with voting machine"
+    line_too_long: "Line to vote is too long"
+    provisional_problem: "Problem with provisional ballot"
+    other: "Other"
+
+  issues_detail:
+    check_in:

--- a/readme.md
+++ b/readme.md
@@ -77,10 +77,18 @@ We welcome help from the community and we are open to pull requests. You can fin
     rails db:migrate
     ```
 
-6. Run!
+6. Create an .env file in the root directory with the following keys(requires Twilio/Google API keys)
+   ```
+   GOOGLE_API_KEY=
+   TWILIO_NUMBER=
+   TWILIO_SID=
+   TWILIO_TOKEN=
+   ```
+
+7. Run!
 
     ```
-    rails s
+    foreman start
     ```
 
 ## License


### PR DESCRIPTION
This merge request cleans up quite a large swath of the code written during the hackathon:

1. Instead of comparing the integer value of the status of a request and mapping each one to a function in MessageHelper, each of the statuses and issues are enumerated in the Request model, with the status of the request tied into a state machine. This enables us to do a simple `@request.process!(nil, @message)` for most use cases, instead of having to mentally remember which status maps to which integer value. We can even do `@request.pending_responder?` to check if the status of the request corresponds to a certain value. See app/models/request.rb for details.
2. MessageHelper has been cleaned up to support changes made above.
3. Removed the setting of session variables in outgoing server-inititated messages(See [Twilio:The Definitive Guide to SMS Conversation Tracking](https://www.twilio.com/blog/2014/07/the-definitive-guide-to-sms-conversation-tracking.html)
4. Form cleanup & flash notices
5. Moved most strings into config/locales/en.yml file. This enables us to translate our application into multiple languages/ give specific strings (eg registration information) for each state in the future.