### PR TITLE
Connecting responders to the last request

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,4 +57,6 @@ gem 'json'
 
 gem 'aasm'
 
+gem 'redis', '~>3.2'
+
 ruby '2.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,7 @@ GEM
     rb-fsevent (0.9.8)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
+    redis (3.3.3)
     sass (3.4.22)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
@@ -173,6 +174,7 @@ DEPENDENCIES
   pg
   puma (~> 3.0)
   rails (~> 5.0.0.1)
+  redis (~> 3.2)
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -5,31 +5,23 @@ class MessagesController < ApplicationController
   require 'json'
   include MessagesHelper
 
-  use Rack::Session::Cookie, :key => 'rack.session',
-                             :path => '/',
-                             :secret => ENV["SECRET_KEY_BASE"]
-
   def reply
     message_body = params["Body"]
     from_number = params["From"]
-    @responder = Responder.find_by phone: from_number 
-    if session["request_id"].nil? && @responder.nil?
+    #check phone sessions to see if user is involved in a current request
+    request_id, responder_id = getFromCache(from_number) 
+    if request_id.nil?
       @req = Request.create!({phone: from_number, status: 1, responder_id: nil})
-      @message = @req.messages.create({body: message_body})
+      setCache(from_number, @req.id, nil) #Create a phone session for future messages in thread
     else
-      if @responder
-        @req = Request.last #TEMPORARY PENDING KEY-VALUE CACHE OF RESPONDERS TO REQUESTS
-      else
-        @req = Request.find(session["request_id"])
-      end
-      @message = @req.messages.create({body: message_body})
+      @req = Request.find(request_id)
     end
-    session["request_id"] = @req.id
+    @message = @req.messages.create({body: message_body})
     boot_twilio
     @nearby = nil
     # when reply, test to return the nearest polling address
-    if @responder and /Y(es)?/i.match(message_body)
-      @body = handle_responder(@req, @responder.id)
+    if responder_id and /Y(es)?/i.match(message_body)
+      @body = handle_responder(@req, responder_id)
     else
       @body, @nearby = handler(@req, @message)
     end
@@ -48,6 +40,7 @@ class MessagesController < ApplicationController
           :body => t(:nearby, address: @req.address, issue: issue, desc: @req.desc)
         )
         puts "Sent request for help to #{person.fname}"
+        setCache(phone, @req.id, person.id)
       end
     end
   end
@@ -58,5 +51,19 @@ class MessagesController < ApplicationController
     @client = Twilio::REST::Client.new(ENV["TWILIO_SID"], ENV["TWILIO_TOKEN"])
   end
 
+  def getFromCache(phone)
+    cached = $redis.get phone
+    if cached.nil?
+      return nil, nil
+    else
+      cachedObj = JSON.parse(cached)
+      return cachedObj["request_id"], cachedObj["responder_id"]
+    end
+  end
+
+  def setCache(phone, request_id, responder_id)
+    $redis.set phone, {"request_id": request_id, "responder_id": responder_id}.to_json
+    $redis.expire phone, 24*60*60 #each session expires in 24 hours
+  end
 
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -22,11 +22,11 @@ class Request < ApplicationRecord
 
     event :process do
       transitions from: :new_request, to: :awaiting_address
-      transitions from: :awaiting_address, to: :awaiting_issue, after: Proc.new {|*args| save_address(*args) }
-      transitions from: :awaiting_issue, to: :check_need_responder, if: Proc.new {|*args| save_issue(*args) }
-      transitions from: :check_need_responder, to: :awaiting_desc, if: Proc.new {|*args| affirmative?(*args) }
-      transitions from: :check_need_responder, to: :resolved, if: Proc.new {|*args| negative?(*args) }
-      transitions from: :awaiting_desc, to: :pending_responder, if: Proc.new{|*args| has_nearby_responders?(*args)}
+      transitions from: :awaiting_address, to: :awaiting_issue, after: Proc.new {|_, message| save_address(message) }
+      transitions from: :awaiting_issue, to: :check_need_responder, if: Proc.new {|_, message| save_issue(message) }
+      transitions from: :check_need_responder, to: :awaiting_desc, if: Proc.new {|_, message| affirmative?(message) }
+      transitions from: :check_need_responder, to: :resolved, if: Proc.new {|_, message| negative?(message) }
+      transitions from: :awaiting_desc, to: :pending_responder, if: Proc.new{|_, message| has_nearby_responders? }
       transitions from: :awaiting_desc, to: :unresolved
       transitions from: :pending_responder, to: :responder_assigned
       transitions from: :responder_assigned, to: :awaiting_feedback
@@ -53,7 +53,7 @@ class Request < ApplicationRecord
     self.save
   end
 
-  def has_nearby_responders?(*args)
+  def has_nearby_responders?
     return Responder.near(self.address,50).count(:all) > 0
   end
 

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,4 @@
+# used to initialize Redis for key-value store (replacing usage of twilio phone sessions)
+require "redis"
+
+$redis = Redis.new(url: ENV['REDIS_URL'])

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,7 @@ Keep an eye out on the list of extra stuff we want to add here. You can see them
 For our tech stack, we are using:
 - Ruby on Rails
 - PostgreSQL
+- Redis
 - Bootstrap
 - Twilio REST API
 - Heroku for Hosting
@@ -41,11 +42,13 @@ We welcome help from the community and we are open to pull requests. You can fin
     rbenv global 2.3.0
     ```
 
-2. Install and start PostgreSQL
+2. Install and start PostgreSQL & Redis
 
     ```
     brew install postgresql
     brew services start postgresql
+    brew install redis
+    redis-server
     ```
 
 3. Clone the repository and then change into the application's directory
@@ -83,6 +86,7 @@ We welcome help from the community and we are open to pull requests. You can fin
    TWILIO_NUMBER=
    TWILIO_SID=
    TWILIO_TOKEN=
+   REDIS_URL=
    ```
 
 7. Run!


### PR DESCRIPTION
Finally had the time to remove the usage of Twilio session cookies (problematic because of 4h expiry & inability to set them on outgoing requests), replacing the usage of sessions with a key-value Redis store that caches requests and responders ID given the phone number of a message, reducing lookup time. 

Also, Request.last is gone :)
Right now I have it such that responders can only reply to the last request that they received, but we can change it to a list if we decide to in the future.